### PR TITLE
Adding mock database for running unit tests

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -26,3 +26,5 @@ jobs:
       - name: Run test script
         working-directory: ./client
         run: npm run test
+        env:
+          USE_MOCK_DATABASE: true

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -27,7 +27,4 @@ jobs:
         working-directory: ./server
         env:
           USE_MOCK_DATABASE: true
-        run: | 
-          echo "is mock database ${{env.USE_MOCK_DATABASE}}"
-          echo "is mock database $USE_MOCK_DATABASE"
-          npm run test
+        run: npm run test

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -9,8 +9,6 @@ jobs:
   test:
     name: Server - Run Unit Tests
     runs-on: ubuntu-latest
-    env:
-      USE_MOCK_DATABASE: true
 
     steps:
       - name: Checkout code
@@ -27,6 +25,8 @@ jobs:
 
       - name: Run test script
         working-directory: ./server
+        env:
+          USE_MOCK_DATABASE: true
         run: | 
           echo "is mock database ${{env.USE_MOCK_DATABASE}}"
           echo "is mock database $USE_MOCK_DATABASE"

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -26,3 +26,5 @@ jobs:
       - name: Run test script
         working-directory: ./server
         run: npm run test
+        env:
+          USE_MOCK_DATABASE: true

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Server - Run Unit Tests
     runs-on: ubuntu-latest
+    env:
+      USE_MOCK_DATABASE: true
 
     steps:
       - name: Checkout code
@@ -25,6 +27,7 @@ jobs:
 
       - name: Run test script
         working-directory: ./server
-        env:
-          USE_MOCK_DATABASE: true
-        run: npm run test
+        run: | 
+          echo "is mock database ${{env.USE_MOCK_DATABASE}}"
+          echo "is mock database $USE_MOCK_DATABASE"
+          npm run test

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Run test script
         working-directory: ./server
-        run: npm run test
         env:
           USE_MOCK_DATABASE: true
+        run: npm run test

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -2,6 +2,7 @@ FROM node:22-slim
 
 # Install Git and other packages using apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
     git \
     bash \
     curl \

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,9 +1,16 @@
-FROM node:22-alpine3.19
+FROM node:22-slim
+
+# Install Git and other packages using apt-get
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    bash \
+    curl \
+    python3 \
+    make \
+    g++ \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
-# Install Git using apk
-RUN apk add --no-cache git
 
 COPY package*.json ./
 

--- a/server/config/database.ts
+++ b/server/config/database.ts
@@ -1,30 +1,49 @@
-import { MongoClient, ServerApiVersion } from "mongodb";
-import Settings from "../settings/index";
+import { MongoClient, ServerApiVersion } from 'mongodb';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import Settings from '../settings/index';
 
-const uri = Settings.dbConnectionString || "mongodb://mongo:27017";
-//@ts-ignore
-const client = new MongoClient(uri, {
-  serverApi: {
-    version: ServerApiVersion.v1,
-    strict: true,
-    deprecationErrors: true,
-  },
-});
 
-async function tryConnection() {
-  try {
+//TODO: Create DatabaseControler using hexagonal arquitecture
+
+let client: MongoClient;
+let uri: string;
+
+export async function setupDatabaseClient() {
+    Settings.useMockDatabase = true;
+    console.log(Settings.useMockDatabase, 'Settings.useMockDatabase');
+
+    if (Settings.useMockDatabase === true) {
+        const mockMongoServer = await MongoMemoryServer.create();
+        uri = mockMongoServer.getUri();
+        console.log(`Connected to mock database at ${uri}`);
+    } else {
+        uri = Settings.dbConnectionString;
+        console.log(`Connected to database at ${uri}`);
+    }
+
+    client = new MongoClient(uri, {
+        serverApi: {
+            version: ServerApiVersion.v1,
+            strict: true,
+            deprecationErrors: true,
+        },
+    });
+
     await client.connect();
-    await client.db("admin").command({ ping: 1 });
-
-    console.log("Connection successful");
-  } catch (err) {
-    console.error("failed to connect", err);
-    throw Error("Failed Database connection");
-  }
+    return client;
 }
 
-tryConnection();
+export function getDatabaseClient() {
+    if (!client) {
+        throw new Error(
+            'Database client is not set up. Call setupDatabaseClient() first.',
+        );
+    }
+    return client;
+}
 
-let db = client.db("library");
-
-export default db;
+export async function closeDatabaseClient() {
+    if (client) {
+        await client.close();
+    }
+}

--- a/server/config/database.ts
+++ b/server/config/database.ts
@@ -2,16 +2,12 @@ import { MongoClient, ServerApiVersion } from 'mongodb';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import Settings from '../settings/index';
 
-
 //TODO: Create DatabaseControler using hexagonal arquitecture
 
 let client: MongoClient;
 let uri: string;
 
 export async function setupDatabaseClient() {
-    Settings.useMockDatabase = true;
-    console.log(Settings.useMockDatabase, 'Settings.useMockDatabase');
-
     if (Settings.useMockDatabase === true) {
         const mockMongoServer = await MongoMemoryServer.create();
         uri = mockMongoServer.getUri();
@@ -45,5 +41,6 @@ export function getDatabaseClient() {
 export async function closeDatabaseClient() {
     if (client) {
         await client.close();
+        console.log('Databse connection closed');
     }
 }

--- a/server/config/server.ts
+++ b/server/config/server.ts
@@ -1,11 +1,12 @@
-import express from "express";
-import cors from "cors";
-import dotenv from "dotenv";
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
 
-import Settings from "../settings/index";
-import { BookController } from "../domains/book/adapters/driver/book-driver.adapter";
+import Settings from '../settings/index';
+import { BookController } from '../domains/book/adapters/driver/book-driver.adapter';
+import { setupDatabaseClient } from './database';
 
-dotenv.config({ path: "../.env" });
+dotenv.config({ path: '../.env' });
 const PORT = Settings.port || 5000;
 const app = express();
 const router = express.Router();
@@ -13,8 +14,11 @@ const router = express.Router();
 app.use(cors());
 app.use(express.json());
 
+//TODO: Create DatabaseControler using hexagonal arquitecture
+setupDatabaseClient();
+
 BookController(app, router);
 
 app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+    console.log(`Server listening on port ${PORT}`);
 });

--- a/server/config/server.ts
+++ b/server/config/server.ts
@@ -1,13 +1,11 @@
 import express from 'express';
 import cors from 'cors';
-import dotenv from 'dotenv';
 
 import Settings from '../settings/index';
 import { BookController } from '../domains/book/adapters/driver/book-driver.adapter';
 import { setupDatabaseClient } from './database';
 
-dotenv.config({ path: '../.env' });
-const PORT = Settings.port || 5000;
+const PORT = Settings.port;
 const app = express();
 const router = express.Router();
 

--- a/server/config/test-runner-global-setup.ts
+++ b/server/config/test-runner-global-setup.ts
@@ -1,0 +1,11 @@
+import { beforeAll, afterAll } from 'vitest';
+import { setupDatabaseClient, closeDatabaseClient } from './database';
+
+// Vitest hooks for global setup/teardown
+beforeAll(async () => {
+    await setupDatabaseClient();
+});
+
+afterAll(async () => {
+    await closeDatabaseClient();
+});

--- a/server/domains/book/__tests__/book-service.spec.ts
+++ b/server/domains/book/__tests__/book-service.spec.ts
@@ -149,8 +149,6 @@ describe('Test Book service', () => {
             expect(BookService.getByFilters).toBeDefined();
             expect(BookService.getByFilters).toBeInstanceOf(Function);
 
-            await BookService.create(Book);
-
             const spy = vi.spyOn(BookService, 'getByFilters');
             const result = await BookService.getByFilters(filters);
 

--- a/server/domains/book/adapters/driven/book-reader.adapter.ts
+++ b/server/domains/book/adapters/driven/book-reader.adapter.ts
@@ -1,40 +1,52 @@
-import express from "express";
+import express from 'express';
 
-import database from "../../../../config/database";
+import { getDatabaseClient } from '../../../../config/database';
 
-import { ObjectId } from "mongodb";
-import { BookEntity } from "../../core/entities/book.entity";
-import { BookReaderDrivenPorts } from "../../ports/driven/book-reader-driven.ports";
-import { BookDatabase } from "../../core/constants/book-database.constants";
-import { BookProcessedFiltersEntity, BookFiltersEntity } from "../../core/entities/book-filters.entity";
+import { ObjectId } from 'mongodb';
+import { BookEntity } from '../../core/entities/book.entity';
+import { BookReaderDrivenPorts } from '../../ports/driven/book-reader-driven.ports';
+import {
+    BookCollection,
+    DatabaseName,
+} from '../../core/constants/book-database.constants';
+import {
+    BookProcessedFiltersEntity,
+    BookFiltersEntity,
+} from '../../core/entities/book-filters.entity';
 
-import { bookHandler } from "../../core/middleware/books.middleware";
+import { bookHandler } from '../../core/middleware/books.middleware';
 
-export function BookReaderAdapter(): BookReaderDrivenPorts{
+export function BookReaderAdapter(): BookReaderDrivenPorts {
     async function getAll(): Promise<BookEntity[]> {
-
         try {
-            let collection = await database.collection(BookDatabase);
+            let collection = await getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
             let results = await collection.find({}).toArray();
             //@ts-ignore
-            const entries: BookEntity[] = results.map((doc) => bookHandler(doc))
-            
-            return entries
+            const entries: BookEntity[] = results.map((doc) =>
+                //@ts-ignore
+                bookHandler(doc),
+            );
+
+            return entries;
         } catch (err) {
-            console.error("Error fetching books", err);
+            console.error('Error fetching books', err);
             return [];
         }
     }
 
-    async function getById(id: string) : Promise<BookEntity | {}> {
+    async function getById(id: string): Promise<BookEntity | {}> {
         try {
             if (!id) {
-                throw new Error("No Id provided");
+                throw new Error('No Id provided');
             }
 
-            let collection = await database.collection(BookDatabase);
+            let collection = await getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
             let query = { _id: new ObjectId(id) };
-            
+
             let result = await collection.findOne(query);
             //@ts-ignore
             const processedResult = bookHandler(result);
@@ -44,51 +56,58 @@ export function BookReaderAdapter(): BookReaderDrivenPorts{
                 return processedResult;
             }
         } catch (err) {
-            console.error("Error fetching book", err);
+            console.error('Error fetching book', err);
             return {};
         }
-    
     }
 
-    async function getByFilters(filters: BookFiltersEntity): Promise<BookEntity[]> {
+    async function getByFilters(
+        filters: BookFiltersEntity,
+    ): Promise<BookEntity[]> {
         try {
             if (!filters) {
-                throw new Error("No Filters provided");
+                throw new Error('No Filters provided');
             }
-            
-            const collection = await database.collection(BookDatabase);
+
+            const collection = await getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
             //@ts-ignore
             const query: BookProcessedFiltersEntity = {};
-            
+
             if (filters.name) {
-                query.name = { $regex: new RegExp(filters.name.toString(), 'i') };
+                query.name = {
+                    $regex: new RegExp(filters.name.toString(), 'i'),
+                };
             }
-            
+
             if (filters.genre && filters.genre.length > 0) {
-                query.genre = { $in:  filters.genre.split(',') };
+                query.genre = { $in: filters.genre.split(',') };
             }
-            
+
             if (filters.author) {
-                query.author = {$regex: new RegExp(filters.author.toString(), 'i') };
+                query.author = {
+                    $regex: new RegExp(filters.author.toString(), 'i'),
+                };
             }
-    
+
             const results = await collection.find(query).toArray();
             //@ts-ignore
-            const entries: BookEntity[] = results.map((doc) => bookHandler(doc));
-            
+            const entries: BookEntity[] = results.map((doc) =>
+                //@ts-ignore
+                bookHandler(doc),
+            );
+
             return entries;
         } catch (err) {
-            console.error("Error fetching books", err);
-            return []; 
+            console.error('Error fetching books', err);
+            return [];
         }
     }
 
     return {
         getAll,
         getById,
-        getByFilters
-    }
+        getByFilters,
+    };
 }
-
-
-

--- a/server/domains/book/adapters/driven/book-writer.adapter.ts
+++ b/server/domains/book/adapters/driven/book-writer.adapter.ts
@@ -1,49 +1,54 @@
-import express from "express";
+import express from 'express';
 
-import database from "../../../../config/database";
+import { getDatabaseClient } from '../../../../config/database';
 
-import { ObjectId } from "mongodb";
-import { BookEntity } from "../../core/entities/book.entity";
-import { BookWriterDrivenPorts } from "../../ports/driven/book-writer-driven.ports";
-import { BookDatabase } from "../../core/constants/book-database.constants";
+import { ObjectId } from 'mongodb';
+import { BookEntity } from '../../core/entities/book.entity';
+import { BookWriterDrivenPorts } from '../../ports/driven/book-writer-driven.ports';
+import {
+    BookCollection,
+    DatabaseName,
+} from '../../core/constants/book-database.constants';
 
 export function BookWritterAdapter(): BookWriterDrivenPorts {
-
     async function create(book: BookEntity): Promise<void> {
         try {
-            let collection = await database.collection(BookDatabase);
+            let collection = await getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
             await collection.insertOne(book);
-
-        } catch(error){
-            console.error("Error adding book", error);
+        } catch (error) {
+            console.error('Error adding book', error);
             return;
         }
     }
 
     async function update(id: string, book: BookEntity): Promise<void> {
         try {
-            let query = {_id: new ObjectId(id) };
+            let query = { _id: new ObjectId(id) };
             const updates = {
-                $set: book
-            }
-    
-            let collection = database.collection(BookDatabase);
-            collection.updateOne(query, updates);
+                $set: book,
+            };
 
+            let collection = getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
+            collection.updateOne(query, updates);
         } catch (error) {
-            console.error("Error updating book", error);
+            console.error('Error updating book', error);
             return;
         }
     }
 
     async function remove(id: string): Promise<void> {
         try {
-            let query = {_id: new ObjectId(id) }
-            const collection = database.collection(BookDatabase);
+            let query = { _id: new ObjectId(id) };
+            const collection = getDatabaseClient()
+                .db(DatabaseName)
+                .collection(BookCollection);
             collection.deleteOne(query);
-    
         } catch (error) {
-            console.error("Error deleting book", error);
+            console.error('Error deleting book', error);
             return;
         }
     }
@@ -51,6 +56,6 @@ export function BookWritterAdapter(): BookWriterDrivenPorts {
     return {
         create,
         update,
-        remove
-    }
+        remove,
+    };
 }

--- a/server/domains/book/adapters/driver/book-driver.adapter.ts
+++ b/server/domains/book/adapters/driver/book-driver.adapter.ts
@@ -1,100 +1,104 @@
-import { Express, Router, Request, Response } from "express";
-import { BookResourcePathConstants } from "../../core/constants/book-resource-path.constants";
-import Books from "../../index";
-import { BookFiltersDTO } from "../../core/dtos/book-filters.dto";
+import { Express, Router, Request, Response } from 'express';
+import { BookResourcePathConstants } from '../../core/constants/book-resource-path.constants';
+import Books from '../../index';
+import { BookFiltersDTO } from '../../core/dtos/book-filters.dto';
 
-export function BookController(app: Express, router: Router) : void {
-    
-    router.get(BookResourcePathConstants.ROOT, async (req: Request, res: Response): Promise<void> => {
-         res.json(await Books.getAll());
-    })
+export function BookController(app: Express, router: Router): void {
+    router.get(
+        BookResourcePathConstants.ROOT,
+        async (req: Request, res: Response): Promise<void> => {
+            res.json(await Books.getAll());
+        },
+    );
 
-    router.get(BookResourcePathConstants.PARAM_ID, async (req: Request, res: Response): Promise<void> => {
-        try {
-            const {id} = req.params;
+    router.get(
+        BookResourcePathConstants.PARAM_ID,
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                const { id } = req.params;
 
-            const response = await Books.getById(id);
+                const response = await Books.getById(id);
 
-            if(!response) {
-                res.status(404);
+                if (!response) {
+                    res.status(404);
+                }
+
+                res.json(response);
+            } catch (err) {
+                console.error(err);
+                res.status(500).send("Couldn't get Book");
             }
+        },
+    );
 
-            res.json(response);
-
-        } catch (err) {
-            console.error(err);
-            res.status(500).send("Couldn't get Book");
-        }
-    })
-
-    router.post(BookResourcePathConstants.ROOT, async (req: Request, res: Response): Promise<void> => {
-        try {
-            res
-            .status(201)
-            .json(await Books.create(req.body));
-            
-        } catch (err) {
-            console.error(err);
-            res.status(500).send("Couldn't create Book");
-        }
-    })
-
-    router.put(BookResourcePathConstants.PARAM_ID, async (req: Request, res: Response): Promise<void> => {
-        try {
-            const {id} = req.params;
-
-            res
-            .status(201)
-            .json(await Books.update(id, req.body));
-            
-        } catch (err) {
-            console.error(err);
-            res.status(500).send("Couldn't update Book");
-        }
-    })
-
-    router.delete(BookResourcePathConstants.PARAM_ID, async (req: Request, res: Response): Promise<void> => {
-        try {
-            const {id} = req.params;
-            
-            res
-            .status(201)
-            .json(await Books.remove(id));
-            
-        } catch (err) {
-            console.error(err);
-            res.status(500).send("Couldn't delete Book");
-        }
-    })
-
-
-    app.get(BookResourcePathConstants.BASE, async (req: Request, res: Response): Promise<void> => {
-        try {
-            const filters: BookFiltersDTO = {};
-            if (req.query.name) {
-                filters.name = req.query.name.toString();
+    router.post(
+        BookResourcePathConstants.ROOT,
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                res.status(201).json(await Books.create(req.body));
+            } catch (err) {
+                console.error(err);
+                res.status(500).send("Couldn't create Book");
             }
-            if (req.query.genre) {
-                filters.genre = req.query.genre.toString()
+        },
+    );
+
+    router.put(
+        BookResourcePathConstants.PARAM_ID,
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                const { id } = req.params;
+
+                res.status(201).json(await Books.update(id, req.body));
+            } catch (err) {
+                console.error(err);
+                res.status(500).send("Couldn't update Book");
             }
-            if (req.query.author) {
-                filters.author = req.query.author.toString();
+        },
+    );
+
+    router.delete(
+        BookResourcePathConstants.PARAM_ID,
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                const { id } = req.params;
+
+                res.status(201).json(await Books.remove(id));
+            } catch (err) {
+                console.error(err);
+                res.status(500).send("Couldn't delete Book");
             }
+        },
+    );
 
-            const response = await Books.getByFilters(filters);
+    app.get(
+        BookResourcePathConstants.BASE,
+        async (req: Request, res: Response): Promise<void> => {
+            try {
+                const filters: BookFiltersDTO = {};
+                if (req.query.name) {
+                    filters.name = req.query.name.toString();
+                }
+                if (req.query.genre) {
+                    filters.genre = req.query.genre.toString();
+                }
+                if (req.query.author) {
+                    filters.author = req.query.author.toString();
+                }
 
-            if(!response) {
-                res.status(404);
+                const response = await Books.getByFilters(filters);
+
+                if (!response) {
+                    res.status(404);
+                }
+
+                res.json(response);
+            } catch (err) {
+                console.error(err);
+                res.status(500).send("Couldn't get Book");
             }
+        },
+    );
 
-            res.json(response);
-
-        } catch (err) {
-            console.error(err);
-            res.status(500).send("Couldn't get Book");
-        }
-    })
-
-
-    app.use(BookResourcePathConstants.BASE, router)
+    app.use(BookResourcePathConstants.BASE, router);
 }

--- a/server/domains/book/core/constants/book-database.constants.ts
+++ b/server/domains/book/core/constants/book-database.constants.ts
@@ -1,1 +1,2 @@
-export const BookDatabase = "books";
+export const DatabaseName = 'library';
+export const BookCollection = 'books';

--- a/server/domains/book/service/book.service.ts
+++ b/server/domains/book/service/book.service.ts
@@ -1,12 +1,14 @@
-import { BookDTO } from "../core/dtos/book.dto";
-import { BookFiltersDTO } from "../core/dtos/book-filters.dto";
-import { BookEntity } from "../core/entities/book.entity";
-import { BookReaderDrivenPorts } from "../ports/driven/book-reader-driven.ports";
-import { BookWriterDrivenPorts } from "../ports/driven/book-writer-driven.ports";
-import { BookDriverPort } from "../ports/driver/book-driver.ports";
+import { BookDTO } from '../core/dtos/book.dto';
+import { BookFiltersDTO } from '../core/dtos/book-filters.dto';
+import { BookEntity } from '../core/entities/book.entity';
+import { BookReaderDrivenPorts } from '../ports/driven/book-reader-driven.ports';
+import { BookWriterDrivenPorts } from '../ports/driven/book-writer-driven.ports';
+import { BookDriverPort } from '../ports/driver/book-driver.ports';
 
-export function BookService(reader: BookReaderDrivenPorts, writer: BookWriterDrivenPorts): BookDriverPort {
-
+export function BookService(
+    reader: BookReaderDrivenPorts,
+    writer: BookWriterDrivenPorts,
+): BookDriverPort {
     async function getAll(): Promise<BookDTO[] | []> {
         const entities: BookEntity[] = await reader.getAll();
 
@@ -14,14 +16,14 @@ export function BookService(reader: BookReaderDrivenPorts, writer: BookWriterDri
             return [];
         }
 
-        return <BookDTO[]>entities.map(entity => ({
+        return <BookDTO[]>entities.map((entity) => ({
             id: entity.id,
             name: entity.name,
             description: entity.description,
             genre: entity.genre,
             image: entity.image,
-            author: entity.author
-        }))
+            author: entity.author,
+        }));
     }
 
     async function getById(id: string): Promise<BookDTO | {}> {
@@ -31,43 +33,43 @@ export function BookService(reader: BookReaderDrivenPorts, writer: BookWriterDri
         if (!entity) {
             return {};
         }
-         
+
         return <BookDTO>{
             id: entity.id,
-            name:entity.name,
+            name: entity.name,
             description: entity.description,
             genre: entity.genre,
             image: entity.image,
-            author: entity.author
-        }
-        
+            author: entity.author,
+        };
     }
 
-    async function getByFilters(filters: BookFiltersDTO): Promise<BookDTO[] | []> {
+    async function getByFilters(
+        filters: BookFiltersDTO,
+    ): Promise<BookDTO[] | []> {
         //@ts-ignore
         const entities: BookEntity[] = await reader.getByFilters(filters);
 
         if (!entities) {
             return [];
         }
-         
-        return <BookDTO[]>entities.map(entity => ({
-            id :entity.id,
+
+        return <BookDTO[]>entities.map((entity) => ({
+            id: entity.id,
             name: entity.name,
             description: entity.description,
             genre: entity.genre,
             image: entity.image,
-            author: entity.author
-        }))
-        
+            author: entity.author,
+        }));
     }
 
     async function create(dto: BookEntity): Promise<void> {
         if (!dto.name.trim()) {
-            return
+            return;
         }
 
-       return await writer.create(dto) 
+        return await writer.create(dto);
     }
 
     async function update(id: string, dto: BookEntity) {
@@ -77,7 +79,7 @@ export function BookService(reader: BookReaderDrivenPorts, writer: BookWriterDri
             return;
         }
 
-       return await writer.update(id, dto) 
+        return await writer.update(id, dto);
     }
 
     async function remove(id: string): Promise<void> {
@@ -87,16 +89,15 @@ export function BookService(reader: BookReaderDrivenPorts, writer: BookWriterDri
             return;
         }
 
-       return await writer.remove(id) 
+        return await writer.remove(id);
     }
 
     return {
-        getAll, 
+        getAll,
         getById,
-        getByFilters, 
-        create, 
-        update, 
-        remove
-    }
-    
+        getByFilters,
+        create,
+        update,
+        remove,
+    };
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,6 +22,7 @@
         "dotenv": "^16.4.5",
         "faker": "^6.6.6",
         "jsdom": "^25.0.1",
+        "mongodb-memory-server": "^10.1.3",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
@@ -1348,6 +1349,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1355,12 +1366,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.1.tgz",
+      "integrity": "sha512-Bw2PgKSrZ3uCuSV9WQ998c/GTJTd+9bWj97n7aDQMP8dP/exAZQlJeswPty0ISy+HZD+9Ex+C7CCnc9Q5QJFmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1432,6 +1458,16 @@
         "node": ">=16.20.1"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1478,6 +1514,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -1564,6 +1613,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1978,6 +2034,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2007,6 +2070,85 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {
@@ -2638,6 +2780,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
@@ -2854,6 +3009,70 @@
         "whatwg-url": "^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.1.3.tgz",
+      "integrity": "sha512-QCUjsIIXSYv/EgkpDAjfhlqRKo6N+qR6DD43q4lyrCVn24xQmvlArdWHW/Um5RS4LkC9YWC3XveSncJqht2Hbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.1.3",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.1.3.tgz",
+      "integrity": "sha512-ayBQHeV74wRHhgcAKpxHYI4th9Ufidy/m3XhJnLFRufKsOyDsyHYU3Zxv5Fm4hxsWE6wVd0GAVcQ7t7XNkivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.7",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.9",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.7.0",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2887,6 +3106,44 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nodemon": {
       "version": "3.1.9",
@@ -2992,6 +3249,45 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -3019,6 +3315,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -3071,6 +3377,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
@@ -3089,6 +3402,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -3163,6 +3489,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3533,6 +3866,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
+      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -3657,6 +4005,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -3696,6 +4056,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tinybench": {
@@ -3872,6 +4242,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4385,6 +4762,20 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^16.4.5",
     "faker": "^6.6.6",
     "jsdom": "^25.0.1",
+    "mongodb-memory-server": "^10.1.3",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.2",

--- a/server/settings/index.ts
+++ b/server/settings/index.ts
@@ -1,4 +1,5 @@
 export default {
-    dbConnectionString: process.env.DATABASE_URI,
-    port: process.env.PORT
-}
+    dbConnectionString: process.env.DATABASE_URI || 'mongodb://mongo:27017',
+    port: process.env.PORT || 5000,
+    useMockDatabase: process.env.USE_MOCK_DATABASE || false,
+};

--- a/server/settings/index.ts
+++ b/server/settings/index.ts
@@ -1,5 +1,8 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 export default {
     dbConnectionString: process.env.DATABASE_URI || 'mongodb://mongo:27017',
     port: process.env.PORT || 5000,
-    useMockDatabase: process.env.USE_MOCK_DATABASE || false,
+    useMockDatabase: process.env.USE_MOCK_DATABASE === 'true' || false,
 };

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,15 +1,16 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    coverage: {
-      exclude: [
-        ...configDefaults.exclude,
-        './config/**',
-        './vitest.config.ts',
-      ],
+    test: {
+        environment: 'jsdom',
+        setupFiles: './config/test-runner-global-setup.ts',
+        globals: true,
+        coverage: {
+            exclude: [
+                ...configDefaults.exclude,
+                './config/**',
+                './vitest.config.ts',
+            ],
+        },
     },
-  },
 });


### PR DESCRIPTION
Added a mock database using mongodb-memory-server to allow to run unit tests for in isolation without the need for running the actual mongodb database.